### PR TITLE
Add LLM cost change analysis to CI

### DIFF
--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -1,0 +1,18 @@
+name: LLM Cost Analysis
+
+on:
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cost-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Jwrede/tokentoll@753ca4d1150c74169b52a843439049b65e256d2b  # v0.6.1


### PR DESCRIPTION
Closing as optional enhancement for now.

This PR adds LLM cost analysis via tokentoll - a useful CI enhancement for tracking API cost changes.

**Reason for closing:**
- CI is still pending
- Focus is on core deployment stability
- Can be re-added post-v1.0 as an enhancement

**Security Review:** ? Approved
- Minimal permissions (contents: read, pull-requests: write)
- Pinned SHA prevents supply chain attacks
- No secrets exposed

This feature can be revisited after the successful v1.0 deployment.