### PR TITLE
fix(ci): fix CodeQL config error + decouple codeql jobs from backend-tests flake

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,5 +1,3 @@
-name: "Custom CodeQL Configuration"
-
 queries:
   - uses: security-extended
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
   codeql-python:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && inputs.enable_deep_analysis == 'true')) }}
-    needs: [security-deps]
+    needs: [backend-lint]
     timeout-minutes: 30
     permissions:
       security-events: write
@@ -300,15 +300,12 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
-        with:
-          category: '/language:python'
-          upload: true
         continue-on-error: true
 
   codeql-javascript:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && inputs.enable_deep_analysis == 'true')) }}
-    needs: [security-deps]
+    needs: [backend-lint]
     timeout-minutes: 30
     permissions:
       security-events: write
@@ -328,9 +325,6 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
-        with:
-          category: '/language:javascript-typescript'
-          upload: true
         continue-on-error: true
 
   container-scan:


### PR DESCRIPTION
## Summary

Fixes the CodeQL 'configuration error' in the Security tab. After my recent merges (#248, #250, #251), the CodeQL jobs (`codeql-python`, `codeql-javascript`) were running as **skipped** instead of executing — this caused the Security tab to show stale data and a config error.

## Root cause (two-part)

1. **Config syntax drift** — `.github/codeql/codeql-config.yml` used `name:` field that's not appropriate for `github/codeql-action@v4`. Action was reporting this as configuration error.
2. **Skip cascade** — `codeql-python`/`codeql-javascript` `needs: [security-deps]`, and `security-deps` `needs: [backend-tests]`. When `backend-tests (unit, tests/unit, 85)` flakes on 5-min step timeout (known issue per project memory), the entire chain gets skipped.

## What this PR changes

**1. `.github/codeql/codeql-config.yml`:**
- Removed `name: "Custom CodeQL Configuration"` field (deprecated for CodeQL Action v4)

**2. `.github/workflows/ci.yml`:**
- Changed `codeql-python` and `codeql-javascript` `needs:` from `[security-deps]` to `[backend-lint]`. This decouples CodeQL from the test-job flake. pip-audit still runs via security-deps as usual.
- Removed explicit `category: '/language:python' / '/language:javascript-typescript'` fields — action auto-determines these from `languages:` input.

## Verification

After this PR merges:
- CodeQL python + javascript jobs execute on every push to dev/main (not skipped)
- Security tab → Code scanning shows current data from `bc312c2` and beyond
- No more 'Configuration error' notification in the Security tab

Out of scope (separate work):
- Bumping backend-tests(unit) pytest step timeout (known flake per project memory `Integration test hang pattern`)