### PR TITLE
feat: add SerpBase (Google) search engine via REST API

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -115,6 +115,17 @@ DATABASE_URL=sqlite+aiosqlite:///./data/auth.db
 # AUTH_LOCKOUT_DURATION_MINUTES=15
 
 # =============================================================================
+# WEB SEARCH (optional, for research/demo agents)
+# =============================================================================
+# SearXNG instance URL (self-hosted metasearch). When unset, the agent falls
+# back to DuckDuckGo HTML scraping.
+# SEARXNG_URL=http://localhost:8080
+# SerpBase API key (optional) - enables hosted Google search results via
+# https://serpbase.dev as an API tier before the DuckDuckGo scrape fallback.
+# Get a key at https://serpbase.dev (free trial included).
+# SERPBASE_API_KEY=
+
+# =============================================================================
 # DEMO MODE (for public staging / showcase)
 # =============================================================================
 # DEMO_MODE=true

--- a/apps/api/tests/unit/test_web_fetch.py
+++ b/apps/api/tests/unit/test_web_fetch.py
@@ -11,6 +11,7 @@ Tests cover:
 - fetch_url_text (safe URL, content types, max bytes, errors)
 - searxng_search (HTML parsing, result extraction, errors)
 - duckduckgo_html_search (HTML parsing, result extraction, errors)
+- serpbase_search (JSON parsing, result extraction, errors)
 """
 
 import ipaddress
@@ -28,6 +29,7 @@ from utils.web_fetch import (
     duckduckgo_html_search,
     fetch_url_text,
     searxng_search,
+    serpbase_search,
 )
 
 # ===========================================================================
@@ -891,3 +893,162 @@ class TestDuckduckgoHtmlSearch:
 
         call_kwargs = mock_get.call_args
         assert "Mozilla/5.0" in call_kwargs[1]["headers"]["User-Agent"]
+
+
+# ===========================================================================
+# Test: serpbase_search
+# ===========================================================================
+
+
+class TestSerpbaseSearch:
+    """Tests for SerpBase REST API result parsing."""
+
+    def test_parses_organic_results(self):
+        """Parses JSON organic_results into WebSearchResult objects."""
+        payload = {
+            "organic_results": [
+                {
+                    "title": "Example Page 1",
+                    "link": "https://example.com/page1",
+                    "snippet": "Snippet for page 1",
+                    "position": 1,
+                },
+                {
+                    "title": "Example Page 2",
+                    "link": "https://example.com/page2",
+                    "snippet": "Snippet for page 2",
+                    "position": 2,
+                },
+            ]
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = payload
+
+        with patch("utils.web_fetch.requests.get", return_value=mock_resp):
+            results = serpbase_search(
+                api_key="test-key",
+                query="test query",
+                max_results=10,
+                timeout_seconds=5,
+            )
+
+        assert len(results) == 2
+        assert isinstance(results[0], WebSearchResult)
+        assert results[0].title == "Example Page 1"
+        assert results[0].url == "https://example.com/page1"
+        assert results[0].snippet == "Snippet for page 1"
+        assert results[1].title == "Example Page 2"
+
+    def test_limits_max_results(self):
+        """Respects max_results parameter."""
+        payload = {
+            "organic_results": [
+                {
+                    "title": f"Title {i}",
+                    "link": f"https://example.com/{i}",
+                    "snippet": f"Snippet {i}",
+                }
+                for i in range(5)
+            ]
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = payload
+
+        with patch("utils.web_fetch.requests.get", return_value=mock_resp):
+            results = serpbase_search(
+                api_key="test-key",
+                query="test",
+                max_results=3,
+                timeout_seconds=5,
+            )
+
+        assert len(results) == 3
+        assert results[0].url == "https://example.com/0"
+
+    def test_skips_entries_without_link(self):
+        """Drops organic results that have no usable link."""
+        payload = {
+            "organic_results": [
+                {"title": "No link", "link": "", "snippet": "x"},
+                {"title": "Valid", "link": "https://example.com/ok", "snippet": "y"},
+            ]
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = payload
+
+        with patch("utils.web_fetch.requests.get", return_value=mock_resp):
+            results = serpbase_search(
+                api_key="test-key",
+                query="test",
+                max_results=10,
+                timeout_seconds=5,
+            )
+
+        assert len(results) == 1
+        assert results[0].url == "https://example.com/ok"
+
+    def test_returns_empty_on_non_200(self):
+        """Non-200 responses produce an empty list, not an exception."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+
+        with patch("utils.web_fetch.requests.get", return_value=mock_resp):
+            results = serpbase_search(
+                api_key="bad-key",
+                query="test",
+                max_results=10,
+                timeout_seconds=5,
+            )
+
+        assert results == []
+
+    def test_returns_empty_on_exception(self):
+        """Network errors produce an empty list, not an exception."""
+        with patch("utils.web_fetch.requests.get", side_effect=Exception("boom")):
+            results = serpbase_search(
+                api_key="test-key",
+                query="test",
+                max_results=10,
+                timeout_seconds=5,
+            )
+
+        assert results == []
+
+    def test_returns_empty_without_api_key(self):
+        """An empty API key is a no-op (graceful degradation)."""
+        results = serpbase_search(
+            api_key="",
+            query="test",
+            max_results=10,
+            timeout_seconds=5,
+        )
+
+        assert results == []
+
+    def test_sends_expected_params(self):
+        """Sends query, api_key, and num to the SerpBase endpoint."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"organic_results": []}
+
+        with patch("utils.web_fetch.requests.get", return_value=mock_resp) as mock_get:
+            serpbase_search(
+                api_key="test-key",
+                query="test query",
+                max_results=7,
+                timeout_seconds=5,
+            )
+
+        call_kwargs = mock_get.call_args
+        assert call_kwargs[0][0] == "https://api.serpbase.dev/google/search"
+        assert call_kwargs[1]["params"] == {
+            "q": "test query",
+            "api_key": "test-key",
+            "num": "7",
+        }

--- a/apps/api/tools/web_tools.py
+++ b/apps/api/tools/web_tools.py
@@ -1,10 +1,16 @@
 import json
+import os
 from typing import Any, Optional
 
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field, PrivateAttr
 
-from utils.web_fetch import duckduckgo_html_search, fetch_url_text, searxng_search
+from utils.web_fetch import (
+    duckduckgo_html_search,
+    fetch_url_text,
+    searxng_search,
+    serpbase_search,
+)
 
 
 class WebSearchInput(BaseModel):
@@ -20,11 +26,13 @@ class WebSearchTool(BaseTool):
     )
 
     _searxng_url: Optional[str] = PrivateAttr()
+    _serpbase_api_key: Optional[str] = PrivateAttr()
     _timeout_seconds: float = PrivateAttr()
 
     def __init__(self, searxng_url: Optional[str], timeout_seconds: float, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._searxng_url = searxng_url.strip() if searxng_url else None
+        self._serpbase_api_key = os.environ.get("SERPBASE_API_KEY", "").strip() or None
         self._timeout_seconds = float(timeout_seconds)
 
     def _run(self, query: str, max_results: int = 5) -> str:
@@ -33,6 +41,14 @@ class WebSearchTool(BaseTool):
         if self._searxng_url:
             results = searxng_search(
                 searxng_url=self._searxng_url,
+                query=query,
+                max_results=int(max_results),
+                timeout_seconds=self._timeout_seconds,
+            )
+        if not results and self._serpbase_api_key:
+            provider = "serpbase"
+            results = serpbase_search(
+                api_key=self._serpbase_api_key,
                 query=query,
                 max_results=int(max_results),
                 timeout_seconds=self._timeout_seconds,

--- a/apps/api/utils/web_fetch.py
+++ b/apps/api/utils/web_fetch.py
@@ -194,3 +194,51 @@ def duckduckgo_html_search(
         return results
     except Exception:
         return []
+
+
+def serpbase_search(
+    *,
+    api_key: str,
+    query: str,
+    max_results: int,
+    timeout_seconds: float,
+) -> list[WebSearchResult]:
+    """Search Google via the SerpBase REST API (https://serpbase.dev).
+
+    Returns an empty list on any error so callers can fall back to other
+    backends. Requires a SerpBase API key; callers without one should not
+    call this function (WebSearchTool only does when SERPBASE_API_KEY is set).
+    """
+    if not api_key:
+        return []
+    params = {
+        "q": query,
+        "api_key": api_key,
+        "num": str(max(1, min(int(max_results), 20))),
+    }
+    headers = {"User-Agent": "ai-real-estate-assistant/1.0"}
+    try:
+        resp = requests.get(
+            "https://api.serpbase.dev/google/search",
+            params=params,
+            headers=headers,
+            timeout=timeout_seconds,
+        )
+        if resp.status_code != 200:
+            return []
+        payload = resp.json()
+        results: list[WebSearchResult] = []
+        for item in (payload.get("organic_results") or [])[: max(0, int(max_results))]:
+            url = str(item.get("link") or "").strip()
+            if not url:
+                continue
+            results.append(
+                WebSearchResult(
+                    title=str(item.get("title") or "").strip(),
+                    url=url,
+                    snippet=str(item.get("snippet") or "").strip(),
+                )
+            )
+        return results
+    except Exception:
+        return []


### PR DESCRIPTION
## Summary
Adds an optional **SerpBase** backend to `WebSearchTool` so the research/demo agents can return Google organic results via a hosted REST API instead of relying solely on self-hosted SearXNG or the fragile DuckDuckGo HTML scrape.

## Background
The current cascade in `tools/web_tools.py` is `SearXNG (if configured) → DuckDuckGo HTML scrape`. DuckDuckGo HTML scraping is brittle (layout changes, rate limiting) and SearXNG requires operators to run their own instance. A hosted search API is a natural third tier: zero infra for the operator, opt-in via one env var, and it degrades silently back to the existing path when unset.

## Changes
- **New**: `serpbase_search()` in `apps/api/utils/web_fetch.py` — calls `GET https://api.serpbase.dev/google/search` and maps `organic_results` (title/link/snippet) into the existing `WebSearchResult` dataclass. Returns `[]` on any error, matching the `searxng_search`/`duckduckgo_html_search` conventions.
- **Updated**: `apps/api/tools/web_tools.py` — `WebSearchTool` reads `SERPBASE_API_KEY` from the environment and inserts SerpBase between SearXNG and DuckDuckGo in the provider cascade. No key → skipped entirely, behavior unchanged.
- **Updated**: `apps/api/tests/unit/test_web_fetch.py` — new `TestSerpbaseSearch` (parsing, max_results, error handling, graceful no-key no-op).
- **Updated**: `apps/api/.env.example` — documents `SEARXNG_URL` and `SERPBASE_API_KEY`.

## Design decisions
| Decision | Rationale |
|----------|-----------|
| Key read directly from env in the tool | Keeps the diff minimal; mirrors how the tool already receives runtime config. Opt-in only — no config/settings plumbing needed |
| SerpBase placed after SearXNG | An operator-configured self-hosted SearXNG keeps priority; SerpBase adds a hosted API tier before the last-resort scrape |
| `num` clamped to 1–20 | Matches SerpBase's documented max per request |
| Empty list on any failure | Follows the project's existing "failures don't block others" backend pattern |

## Testing
- `python3 -m pytest tests/unit/test_web_fetch.py -q` → **84 passed** (incl. 7 new SerpBase tests)
- `python3 -m compileall` on all changed files → OK
- When `SERPBASE_API_KEY` unset: `_serpbase_api_key` is `None`, cascade skips SerpBase, existing SearXNG/DuckDuckGo behavior untouched
- When set and API returns 200: organic results mapped to `{query, provider: "serpbase", results: [...]}`
- When set and API errors/non-200: falls through to DuckDuckGo
