### PR TITLE
chore(release): v5.1.5 version bump + CHANGELOG promotion (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.5] - 2026-09-06
+
+### Added
+- **Visibility / measurement surface** (squash of `v5.1.1..v5.1.4` work via PR #290): new
+  `apps/web/public/llms.txt` (factual AI discovery metadata), `apps/web/src/lib/structured-data.ts`
+  (website schema for SEO), `apps/web/src/lib/site.ts` (canonical/robots), homepage
+  `themeColor` viewport export, sitemap no-op cleanup, Render demo noindex toggle,
+  star-history chart switch to hosted `api.star-history.com` SVG embed (replaces
+  broken self-hosted `star-history` orphan-branch chart and its `GH_STAR_TOKEN`
+  cron workflow). Dependabot override floors added in `apps/web/package.json`
+  for `cross-spawn`, `glob`, `tar`, `flatted`, `serialize-javascript`, `pify`,
+  `globby`, `eslint-plugin-react`, `uuid`, `tmp`, `postcss`, `fast-uri`, `js-yaml`
+  (3.x/4.x), `nanoid`, `dompurify`. Test health: 2 xfail markers in
+  `tests/unit/api/test_health.py` for F-20260903-01/02 (Linux CI flake on
+  `get_vector_store` monkeypatch). Rule 5 invariant: `scripts/rule5_guard/gitignored_tracked_check.py`
+  + `make rule5-guard` target + `.github/workflows/ci.yml:rule5-protected-paths` job.
+
+### Changed
+- **Dependabot bump roll-up** (dev-sync via PR #292): `zod` 4.4.3→4.5.4 (#289),
+  `concurrently` 8.2.2→10.0.5 (#286), `@testing-library/react` 16.3.2→16.3.3 (#277),
+  `jest-environment-jsdom` 30.4.1→30.5.0 (#279), `@types/node` 26.2.0→26.4.0 (#281),
+  `next-intl` 4.13.6→4.14.1 (#282), `tiktoken` ≥0.13.0→≥0.14.0 (#273), `grpcio`
+  ≥1.80.0→≥1.83.1 (#278), `orjson` ≥3.11.9→≥3.12.0 (#280), `tornado` 6.5.7→6.5.8 (#284),
+  `pip` 26.1.2→26.2 (#285), `lewagon/wait-on-check-action` 1.3.4→1.9.1 (#283).
+- **Security bumps**: `js-yaml` 4.x→4.3.1 + 3.x→3.15.1 (HIGH CVE GHSA-5p4m-2h3v-55h9
+  quadratic CPU), `nanoid` →5.1.16 (HIGH CVE GHSA-28wg-ghj8-5hjv infinite-loop),
+  `dompurify` →3.4.13 (MEDIUM CVE GHSA-55q2-fjhq-7xh7 XSS via IN_PLACE hook),
+  `extract-zip` ≤2.0.1 symlink-traversal dismissed as `tolerable_risk` (no upstream
+  fix; dev-only Lighthouse CI CLI), `aiohttp` 3.14.1→3.14.3, `brace-expansion`
+  1.1.13→1.1.18, `ip-address` 10.2.0→10.4.0, `next` 16.2.7→16.2.12, `gitpython`
+  ≥3.1.50→≥3.1.57, 5-Dependabot-alert manual fix, 12-Dependabot-HIGH-CVE 6-bump
+  sweep, `cryptography` 46.0.7→50.0.0 (CVE-2026-69247), `postcss` 8.5.25 +
+  `fast-uri` override 3.1.5.
+- **CI hardening**: ESLint `react-hooks` opt-in rules (`set-state-in-effect`,
+  `static-components`, `immutability`, `preserve-manual-memoization`) temporarily
+  disabled in `apps/web/eslint.config.mjs` (4 of them; per-page re-enablement
+  needs React Query / SWR refactor). CodeQL `queries: security-extended` input
+  removed (mutually exclusive with `config-file:` per codeql-action docs).
+  Private Vulnerability Reporting enabled via `PUT /repos/{owner}/{repo}/private-vulnerability-reporting`.
+  Dependabot auto-merge fail-closed on missing checks; matrix-suffixed
+  backend-tests wait; 3 stacked bugs blocking auto-merge fixed.
+- **Render deploy hardening**: staging "Active" badge fix (auto_inactive=false
+  at deployment CREATION, not status POST); hibernate-503 + 409 race hardening;
+  frontend warm-up 307/308 acceptance; `/health` curl timeout added.
+- **Documentation**: `docs/{database,deployment,development,guides,security}/`
+  reorganization (move from `docs/community/`, `docs/QUICKSTART_*`, `docs/SCRIPTS.md`,
+  `docs/enrichment-extension-pattern.md`, `docs/mcp-audit-logging.md`); accepted-risks
+  doc refresh (6 alerts). `docs/quality/findings.md` ledger initialized with
+  F-20260903-01/02 and F-20260905-1/2/3 references.
+- **Scripts reorg**: `scripts/{demo,dev,docker,setup,utils}/` canonical layout
+  (was flat). `scripts/setup/bootstrap.py` and `scripts/utils/regen_dark_placeholders.js`
+  added. 31 binary screenshots regenerated.
+
 ### Fixed
+- **Pre-existing test failures** (PR #291): 40 unit tests on `main@50e98ad` baseline
+  marked `xfail(strict=False)` with F-20260905-4..12 references (k8s health endpoints,
+  main lifecycle, uptime monitor, adapter retry, data adapters base, excel ingest,
+  port config, services and leads weasyprint, user repos token hashing).
+  Dev-sync (PR #292) brought in the underlying fixes (`d8a9004`,
+  `5548055`, `93179d8` test(health) xfails + deterministic async-mocks + Linux CI
+  outer timeout), making these xfails non-essential on the dev-sync branch but
+  remaining as defensive documentation on `main`.
+- **Profile star-history chart**: replaced broken self-hosted `star-history` orphan-branch
+  chart with hosted `https://api.star-history.com/svg?repos=...&type=Date` endpoint.
+  Removed the dead workflow (`.github/workflows/star-history.yml`), script
+  (`.github/scripts/render_star_history.py`), and its tests. Chart now live-renders
+  with no token, no cron, no orphan branch.
+- **i18n**: missing translation keys added for 8 non-English locales; eliminates
+  MISSING_MESSAGE warnings from frontend build.
+- **Next.js 16 metadata deprecations**: `themeColor` moved to viewport export;
+  `middleware.ts` → `proxy.ts` migration completed (task #12).
+
+### Notes
+- v5.1.5 closes the gap between v5.1.4 (latest tag) and `main@3784b5f`. The
+  pyproject/package.json/PKG-INFO version fields had been stale at `5.0.12`
+  since 2026-06-22 — 5 missed releases (v5.1.0..v5.1.4) before this bump.
+- Cherry-pick strategy: PR #290 (visibility squash from `5ad3561..34e037d`) +
+  PR #292 (dev-sync `git merge -X theirs dev --no-ff --allow-unrelated-histories`
+  bringing 59 non-visibility commits). PR #291 (Phase B xfail PR) is documentation-only.
+- 7 Dependabot alerts at start of v5.1.5 cycle: 6 closed by these bumps,
+  1 dismissed as `tolerable_risk` (extract-zip).
 
 - **docs (profile star-history chart)**: replaced broken self-hosted
   `star-history` orphan-branch chart with the hosted

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ OWASP-hardened with rate limiting, audit logging, SSRF protection, and dual-mode
 
 | Version | Date | Highlights |
 |---|---|---|
+| [v5.1.5](CHANGELOG.md#515---2026-09-06) | 2026-09-06 | Visibility/SEO/GEO surface, star-history hosted embed, Dependabot roll-up, CI hardening |
 | [v5.0.12](CHANGELOG.md#5012---2026-06-22) | 2026-06-22 | Flaky-test fix, deploy independence, release verification workflow |
 | [v5.0.11](CHANGELOG.md#5011---2026-06-22) | 2026-06-22 | `pydantic-settings` CVE, dependabot config fix, first GitHub Release page |
 | [v5.0.10](CHANGELOG.md#5010---2026-06-20) | 2026-06-20 | `aiohttp` 9 advisories, `fastapi` 4 advisories, starlette direct dep |

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-real-estate-assistant"
-version = "5.0.12"
+version = "5.1.5"
 description = "AI-powered real estate assistant with FastAPI backend and Next.js frontend"
 authors = [
     {name = "Alex Nesterovich", email = "alex@example.com"}

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "5.0.12",
+  "version": "5.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "5.0.12",
+      "version": "5.1.5",
       "license": "MIT",
       "dependencies": {
         "@ducanh2912/next-pwa": "10.2.9",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "5.0.12",
+  "version": "5.1.5",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-real-estate-assistant-monorepo",
-  "version": "5.0.3",
+  "version": "5.1.5",
   "description": "Open-source AI real estate assistant with RAG, vector search, multi-provider LLM routing, FastAPI, Next.js, and ChromaDB.",
   "private": true,
   "directories": {


### PR DESCRIPTION
## Description

Prepares the v5.1.5 release on top of the dev-sync PR #292 (`3784b5f`).

## Changes

| File | Change |
|---|---|
| `apps/api/pyproject.toml` | `version = "5.0.12"` → `5.1.5` |
| `apps/web/package.json` | `"version": "5.0.12"` → `5.1.5` |
| `apps/web/package-lock.json` | 2 occurrences updated |
| `package.json` (root) | `5.0.3` → `5.1.5` |
| `CHANGELOG.md` | `[Unreleased]` → `[5.1.5] - 2026-09-06` with full Added/Changed/Fixed/Notes entries |
| `README.md` | v5.1.5 row inserted above v5.0.12 in Releases table |

## Context

Latest tag = v5.1.4. Version files had been stale at `5.0.12` since
2026-06-22 — 5 missed releases (v5.1.0..v5.1.4) before this bump.

Dependant on:
- PR #290 squash (`3ebcda5`) — visibility work
- PR #291 (`fda9063d`) — xfail work
- PR #292 (`3784b5f`) — dev-sync

## Atomic commits (3)

1. `c60693e chore(release): v5.1.5 version bump`
2. `4161d7e docs(changelog): promote [Unreleased] to [5.1.5] - 2026-09-06`
3. `d19bd2b docs(readme): add v5.1.5 to Releases table`

## Verification

- `make rule5-guard` clean
- All diffs are version strings + CHANGELOG entry + README row (no code changes)

## Notes

- v5.1.5 is a patch release on the v5.1 line (visibility/SEO/GEO surface
  + Dependabot roll-up + CI hardening).
- Does NOT update `What's New in v5.1` heading (existing prose still
  applies since 5.1.5 is incremental).

Fixes # (issue)
Refs: PR #290, #291, #292; F-20260905-1/2/3.